### PR TITLE
Explore some initial type definitions

### DIFF
--- a/build.hxml
+++ b/build.hxml
@@ -1,0 +1,2 @@
+-cp src
+--run Main

--- a/build.hxml
+++ b/build.hxml
@@ -1,2 +1,3 @@
 -cp src
 --run Main
+--macro nullSafety("smalluniverse", Strict)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "repository": "https://github.com/jasononeil/smalluniverse",
   "author": "Jason O'Neil",
   "license": "MIT",
+  "scripts": {
+    "build": "haxe build.hxml"
+  },
   "dependencies": {
     "lix": "^15.9.1"
   }

--- a/src/Main.hx
+++ b/src/Main.hx
@@ -1,3 +1,5 @@
+import smalluniverse.SmallUniverse;
+
 function main() {
 	trace("Small Universe");
 }

--- a/src/Main.hx
+++ b/src/Main.hx
@@ -1,0 +1,3 @@
+function main() {
+	trace("Small Universe");
+}

--- a/src/smalluniverse/DOM.hx
+++ b/src/smalluniverse/DOM.hx
@@ -1,0 +1,38 @@
+package smalluniverse;
+
+import smalluniverse.SmallUniverse;
+
+inline function element<Action>(tag:String, attrs:Array<HtmlAttribute<Action>>, children:Array<Html<Action>>)
+	return Element(tag, attrs, children);
+
+inline function text<Action>(text:String)
+	return Text(text);
+
+inline function comment<Action>(text:String)
+	return Comment(text);
+
+// TODO: add some better typing for attributes
+
+inline function div<Action>(attrs:Array<HtmlAttribute<Action>>, children:Array<Html<Action>>)
+	return element("div", attrs, children);
+
+inline function span<Action>(attrs:Array<HtmlAttribute<Action>>, children:Array<Html<Action>>)
+	return element("span", attrs, children);
+
+inline function h1<Action>(attrs:Array<HtmlAttribute<Action>>, children:Array<Html<Action>>)
+	return element("h1", attrs, children);
+
+inline function h2<Action>(attrs:Array<HtmlAttribute<Action>>, children:Array<Html<Action>>)
+	return element("h2", attrs, children);
+
+inline function h3<Action>(attrs:Array<HtmlAttribute<Action>>, children:Array<Html<Action>>)
+	return element("h3", attrs, children);
+
+inline function h4<Action>(attrs:Array<HtmlAttribute<Action>>, children:Array<Html<Action>>)
+	return element("h4", attrs, children);
+
+inline function h5<Action>(attrs:Array<HtmlAttribute<Action>>, children:Array<Html<Action>>)
+	return element("h5", attrs, children);
+
+inline function h6<Action>(attrs:Array<HtmlAttribute<Action>>, children:Array<Html<Action>>)
+	return element("h6", attrs, children);

--- a/src/smalluniverse/SmallUniverse.hx
+++ b/src/smalluniverse/SmallUniverse.hx
@@ -1,0 +1,85 @@
+package smalluniverse;
+
+import haxe.ds.Option;
+
+interface Router {
+	function routeToUri<PageParams>(page:Page<Dynamic, PageParams, Dynamic>, params:PageParams):Option<String>;
+	function uriToRoute<PageParams>(uri:String):Option<{page:Page<Dynamic, PageParams, Dynamic>, params:PageParams}>;
+}
+
+interface Projection<Action> {
+	function handleAction(action:Action):Void;
+	// Projection lifecycle methods?
+	// version: Int;
+	// state: Starting, Ready, Stalled
+}
+
+interface CommandHandler<Action> extends Projection<Action> {
+	// Does this as a separate method make sense? What if we want to use a DB transaction?
+	// Perhaps a CommandHandler is purely a projection, and `handleAction()` rejects if not allowed?
+	function allowAction(action:Action):Bool;
+}
+
+interface PageApi<Action, PageParams, PageData> {
+	function getPageData(pageParams:PageParams):PageData;
+	// Optional: we could use this for websocket updates.
+	function pageDataShouldUpdate(pageParams:PageParams, action:Action):Bool;
+}
+
+interface PageView<Action, PageData> {
+	function render(data:PageData):Html<Action>;
+}
+
+enum Page<Action, PageParams, PageData> {
+	// Should these be instances or classes that we instantiate as needed?
+	Page(view:PageView<Action, PageData>, api:PageApi<Action, PageParams, PageData>);
+}
+
+interface Component<Props, State, InnerAction, OuterAction> {
+	function render(props:Props, state:State):Html<InnerAction>;
+	function defaultState(props:Props):State;
+	function update(currentState:State, action:InnerAction):{newState:State, outerAction:Option<OuterAction>}
+}
+
+enum Html<Action> {
+	Element(tag:String, attrs:Array<HtmlAttribute<Action>>, children:Array<Html<Action>>);
+	Text(text:String);
+	Comment(text:String);
+	// TODO: Component
+}
+
+enum HtmlAttribute<Action> {
+	Attribute(name:String, value:String);
+	Property(name:String, value:Any);
+	Event(on:String, fn:() -> Option<Action>);
+}
+
+function mapHtml<InnerAction, OuterAction>(html:Html<InnerAction>, convert:InnerAction->Option<OuterAction>):Html<OuterAction> {
+	switch html {
+		case Element(tag, attrs, children):
+			return Element(tag, attrs.map(a -> mapAttr(a, convert)), children.map(c -> mapHtml(c, convert)));
+		case Text(text):
+			return Text(text);
+		case Comment(text):
+			return Comment(text);
+	}
+}
+
+function mapAttr<InnerAction, OuterAction>(attr:HtmlAttribute<InnerAction>, convert:InnerAction->Option<OuterAction>):HtmlAttribute<OuterAction> {
+	switch attr {
+		case Attribute(name, value):
+			return Attribute(name, value);
+		case Property(name, value):
+			return Property(name, value);
+		case Event(on, innerFn):
+			function outerFn() {
+				switch innerFn() {
+					case Some(v):
+						return convert(v);
+					case None:
+						return None;
+				}
+			}
+			return Event(on, outerFn);
+	}
+}


### PR DESCRIPTION
## Changes

- Set up some Haxe boilerplate
- Set up a `smalluniverse.SmallUniverse` file that has enums and interfaces to describe the pieces of this architecture
- Set up a `smalluniverse.DOM` file that has shortcuts for creating DOM nodes

## About the types

- **Router** - given a URL, find out which `Page` we're loading, and get the page parameters based on the URL.
- **Page** - represents a page the user can visit. Made up of a `PageApi` and `PageView`
- **PageApi** - given some parameters (from the router) generate the "PageData" required to render the page. Also we might use this for handling websocket subscriptions in future.
- **PageView** - given the "PageData" from the API, generate the `Html` typed representation of the page.
- **Html** - a representation of something to be rendered, an element, some text, or a comment etc. We also have the related `HtmlAttribute`. These have a type parameter representing the types of events that can be triggered by that piece of HTML. This allows us to ensure that any events on the page are of a type that our app knows how to process.
- **CommandHandler** - A back end task that checks if actions/events that come from the client are allowed to occur.
- **Projection** - A back end task that responds to actions/events that come from the client and processes them, often updating a database or something similar. The projection can then by used by `PageApi`s to fetch the data for a page.
- **Component** - At some point I'll probably want a way to define a "component", a small unit that generates HTML but has it's own local state, and some lifecycle hooks. I'm not sure how exactly I'll handle this yet.

## About the DOM helpers

- This is hardly exhaustive, and intended for quick testing.
- I should probably look at adapting this project https://github.com/HaxeFoundation/html-externs/ to generate custom functions for every possible DOM type in Mozilla's definitions, similar to how Haxe does for `js.html.*` definitions.